### PR TITLE
Minor Optimizations

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,6 +1,3 @@
-from enum import Enum
-
-
 class AnsiColor:
     BLUE = "\033[94m"  # Blue for directories
     GREEN = "\033[92m"  # Green for Python files


### PR DESCRIPTION
```
❯ hyperfine "python -m src.main"
Benchmark 1: python -m src.main
  Time (mean ± σ):     696.4 ms ±  12.0 ms    [User: 434.3 ms, System: 256.3 ms]
  Range (min … max):   682.9 ms … 722.5 ms    10 runs

❯ git stash
Saved working directory and index state WIP on main: 3f07e12 fix(gitignore): add __pycache__ to gitignore

❯ hyperfine "python -m src.main"
Benchmark 1: python -m src.main
  Time (mean ± σ):     834.8 ms ±   5.0 ms    [User: 544.4 ms, System: 281.3 ms]
  Range (min … max):   824.1 ms … 841.7 ms    10 runs
```

`get_color` is optimized to use `str.find` instead of `os.path.splitext`. It also uses less instructions via skipping on the if conditional which was checked before. On average, no exceptions should happen, which contributes to an overall performance improvement.

Two very frequent usages of `os.path.join` has been replaced by a f-string to make room for further performance improvements. As for safety, I believe it should not be a concern since on `main` you check whether or not the directory is valid with a call to `os.path.isdir`, and on subsequent recursions of `print_tree` it should also not be an issue since the operating system ensures that the source tree is valid.

Use of `enumerate` has been skipped in favor of more performant and simpler solution of integer addition. Normally use of `enumerate` would not be performance concern, however `print_tree` happens to be sufficiently active on runtime to be somewhat of a bottleneck here.